### PR TITLE
Add dependency to curl 7.65.3-1

### DIFF
--- a/topicexplorer-context/Docker_topicexplorer
+++ b/topicexplorer-context/Docker_topicexplorer
@@ -68,7 +68,7 @@ RUN  cd /topicexplorer/treetagger \
 
 RUN apt-get  update
 RUN apt-get install -y --no-install-recommends mariadb-client netbase
-RUN apt-get install -y --no-install-recommends nginx curl
+RUN apt-get install -y --no-install-recommends nginx curl=7.65.3-1
 RUN apt-get install -y --no-install-recommends libmecab-jni mecab-ipadic-utf8
 
 


### PR DESCRIPTION
```bash
$ docker-compose build
```
yields the following error:
```
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 curl : Depends: libcurl4 (= 7.65.1-1) but 7.65.3-1 is to be installed
``` 

Solution: I added version``` 7.65.3-1``` as a dependency